### PR TITLE
support azure gpt3.5 and gpt4

### DIFF
--- a/docs/add_chatgpt.md
+++ b/docs/add_chatgpt.md
@@ -1,0 +1,28 @@
+# Chatgpt
+
+You can add access to chatgpt(openai/azure) in fastchat
+
+# How
+
+1. Add environment variables.  
+```shell
+# GPT-3.5-turbo
+export OPENAI_API_BASE_GPT35="xxx"
+export OPENAI_API_KEY_GPT35="xxx"
+export OPENAI_API_VERSION_GPT35="xxx"
+export OPENAI_API_TYPE_GPT35="xxx"
+export OPENAI_ENGINE_GPT35="xxx"
+
+# GPT-4
+export OPENAI_API_BASE_GPT4="xxx"
+export OPENAI_API_KEY_GPT4="xxx"
+export OPENAI_API_VERSION_GPT4="xxx"
+export OPENAI_API_TYPE_GPT4="xxx"
+export OPENAI_ENGINE_GPT4="xxx"
+```
+
+2. Add the `--add-chatgpt` command when starting the web service.  
+```shell
+python3 -m fastchat.serve.gradio_web_server  --add-chatgpt
+python3 -m fastchat.serve.gradio_web_server_multi  --add-chatgpt
+```

--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -35,8 +35,22 @@ def openai_api_stream_iter(
     }
     logger.info(f"==== request ====\n{gen_params}")
 
+    engine = ""
+    if model_name == "gpt-3.5-turbo":
+        openai.api_base = os.getenv("OPENAI_API_BASE_GPT35")
+        openai.api_key = os.getenv("OPENAI_API_KEY_GPT35")
+        openai.api_version = os.getenv("OPENAI_API_VERSION_GPT35")
+        openai.api_type = os.getenv("OPENAI_API_TYPE_GPT35")
+        engine = os.getenv("OPENAI_ENGINE_GPT35")
+    elif model_name == "gpt-4":
+        openai.api_base = os.getenv("OPENAI_API_BASE_GPT4")
+        openai.api_key = os.getenv("OPENAI_API_KEY_GPT4")
+        openai.api_version = os.getenv("OPENAI_API_VERSION_GPT4")
+        openai.api_type = os.getenv("OPENAI_API_TYPE_GPT4")
+        engine = os.getenv("OPENAI_ENGINE_GPT4")
     res = openai.ChatCompletion.create(
         model=model_name,
+        engine=engine,
         messages=messages,
         temperature=temperature,
         max_tokens=max_new_tokens,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The web server originally did not support configuration for chatgpt. Here, support for chatgpt from openai and azure is added, including gpt3.5 and gpt4.

<!-- Please give a short summary of the change and the problem this solves. -->
1. In serve/api_provider.py, support for reading and setting environment variables for gpt-3.5-turbo and gpt4 is added, and the engine setting is added to ChatCompletion (azure need).
2. A new document add_chatgpt.md is added to docs to explain how to add chatgpt.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've run `format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the relevant tests are passing (if applicable).
